### PR TITLE
Better condition check for Raspberry Pi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ clean:
 	make -C $(KERNEL_SRC) SUBDIRS=$(PWD) M=$(PWD) clean
 endif
 
-ifeq ($(shell uname -n),raspberrypi)
+ifeq ($(shell lsb_release -is),Raspbian)
 	KERNEL_SRC=/lib/modules/$(shell uname -r)/build
 
 all:


### PR DESCRIPTION
The current Makefile condition check is based on the hostname, but it is too environmentally dependent. As a better practice, I suggest a checking method that uses `lsb_release -i` instead of `uname -n`.

`lsb_release` provides distribution specific information of your running operating system, for example:

```
$ lsb_release -a
No LSB modules are available.
Distributor ID: Raspbian
Description:    Raspbian GNU/Linux 10 (buster)
Release:        10
Codename:       buster
```

Unfortunately, I don't have any other system like Armadillo, so those checks still use `uname -n` in this PR.